### PR TITLE
update pybind11

### DIFF
--- a/packages/p/pybind11/xmake.lua
+++ b/packages/p/pybind11/xmake.lua
@@ -7,20 +7,33 @@ package("pybind11")
 
     add_urls("https://github.com/pybind/pybind11/archive/$(version).zip",
              "https://github.com/pybind/pybind11.git")
+    add_versions("v2.5.0", "1859f121837f6c41b0c6223d617b85a63f2f72132bae3135a2aa290582d61520")
+    add_versions("v2.6.2", "0bdb5fd9616fcfa20918d043501883bf912502843d5afc5bc7329a8bceb157b3")
+    add_versions("v2.7.1", "350ebf8f4c025687503a80350897c95d8271bf536d98261f0b8ed2c1a697070f")
+    add_versions("v2.8.1", "90907e50b76c8e04f1b99e751958d18e72c4cffa750474b5395a93042035e4a3")
+    add_versions("v2.9.1", "ef9e63be55b3b29b4447ead511a7a898fdf36847f21cec27a13df0db051ed96b")
+    add_versions("v2.9.2", "d1646e6f70d8a3acb2ddd85ce1ed543b5dd579c68b8fb8e9638282af20edead8")
+    add_versions("v2.10.0", "225df6e6dea7cea7c5754d4ed954e9ca7c43947b849b3795f87cb56437f1bd19")
     add_versions("v2.11.1", "b011a730c8845bfc265f0f81ee4e5e9e1d354df390836d2a25880e123d021f89")
 
-    on_install(function (package)
-        os.cp("include", package:installdir())
+    add_deps("cmake", "python 3.x")
+    on_install("windows", "macosx", "linux", function (package)
+        local configs = {"-DPYBIND11_TEST=OFF"}
+        local pythonpath, err = os.iorun("python -c \"import sys; print(sys.executable)\"")
+        if pythonpath then
+            table.insert(configs, "-DPYTHON_EXECUTABLE=" .. pythonpath)
+        end
+        import("package.tools.cmake").install(package, configs)
     end)
 
-    -- on_test(function (package)
-    --     assert(package:check_cxxsnippets({test = [[
-    --         #include <pybind11/pybind11.h>
-    --         int add(int i, int j) {
-    --             return i + j;
-    --         }
-    --         PYBIND11_MODULE(example, m) {
-    --             m.def("add", &add, "A function which adds two numbers");
-    --         }
-    --     ]]}, {configs = {languages = "c++11"}}))
-    -- end)
+    on_test(function (package)
+        assert(package:check_cxxsnippets({test = [[
+            #include <pybind11/pybind11.h>
+            int add(int i, int j) {
+                return i + j;
+            }
+            PYBIND11_MODULE(example, m) {
+                m.def("add", &add, "A function which adds two numbers");
+            }
+        ]]}, {configs = {languages = "c++11"}}))
+    end)


### PR DESCRIPTION
See https://github.com/xmake-io/xmake-repo/pull/2976.

This builds fine on my Arch Linux x86, they reported problem on Windows x86 and ARM. I don't have a Windows
environment on hand, but if they have made it working we can switch to the official version.